### PR TITLE
chore: add MIT license and fix module import paths in docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Juan Manuel Armero
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # go-utils
 
+[![CI](https://github.com/juanMaAV92/go-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/juanMaAV92/go-utils/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/juanMaAV92/go-utils.svg)](https://pkg.go.dev/github.com/juanMaAV92/go-utils)
+[![Go Report Card](https://goreportcard.com/badge/github.com/juanMaAV92/go-utils)](https://goreportcard.com/report/github.com/juanMaAV92/go-utils)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 Go utility library for building microservices on AWS. Single module, consistent patterns across all packages: `ConfigFromEnv`, interface-driven design, OTel tracing.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Go utility library for building microservices on AWS. Single module, consistent patterns across all packages: `ConfigFromEnv`, interface-driven design, OTel tracing.
 
 ```bash
-go get github.com/juanmaAV/go-utils
+go get github.com/juanMaAV92/go-utils
 ```
 
 Requires Go 1.21+.

--- a/cache/redis/README.md
+++ b/cache/redis/README.md
@@ -5,7 +5,7 @@ Redis client with JSON serialization, OTel tracing/metrics, Pub/Sub, and atomic 
 ## Setup
 
 ```go
-import "github.com/juanmaAV/go-utils/cache/redis"
+import "github.com/juanMaAV92/go-utils/cache/redis"
 
 cfg, err := redis.ConfigFromEnv("REDIS")
 if err != nil {

--- a/database/postgresql/README.md
+++ b/database/postgresql/README.md
@@ -5,7 +5,7 @@ PostgreSQL client built on [GORM](https://gorm.io) with OTel tracing, structured
 ## Setup
 
 ```go
-import "github.com/juanmaAV/go-utils/database/postgresql"
+import "github.com/juanMaAV92/go-utils/database/postgresql"
 
 // From environment variables
 cfg, err := postgresql.ConfigFromEnv("DB")  // reads DB_HOST, DB_USER, DB_PASSWORD, DB_NAME …

--- a/env/README.md
+++ b/env/README.md
@@ -54,7 +54,7 @@ env.LocalEnvironment  // "local"
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/env"
+import "github.com/juanMaAV92/go-utils/env"
 
 // Validate all required vars at once — fail with a clear message
 env.MustHave("PORT", "DATABASE_URL", "JWT_SECRET")

--- a/errors/README.md
+++ b/errors/README.md
@@ -64,7 +64,7 @@ errors.ValidationErrorCode       // "VALIDATION_ERROR"
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/errors"
+import "github.com/juanMaAV92/go-utils/errors"
 
 // Return predefined
 return errors.ErrNotFound()
@@ -87,7 +87,7 @@ if errors.As(err, &appErr) {
 ## Echo integration
 
 ```go
-import echoerr "github.com/juanmaAV/go-utils/errors/echo"
+import echoerr "github.com/juanMaAV92/go-utils/errors/echo"
 
 e.HTTPErrorHandler = echoerr.HTTPErrorHandler
 ```

--- a/httpclient/README.md
+++ b/httpclient/README.md
@@ -64,7 +64,7 @@ resp, err := c.Post(ctx, "/form", nil,
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/httpclient"
+import "github.com/juanMaAV92/go-utils/httpclient"
 
 c := httpclient.New(log,
     httpclient.WithBaseURL("https://api.example.com"),

--- a/logger/README.md
+++ b/logger/README.md
@@ -35,7 +35,7 @@ Available levels: `FatalLevel`, `ErrorLevel`, `WarningLevel`, `InfoLevel`, `Debu
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/logger"
+import "github.com/juanMaAV92/go-utils/logger"
 
 log := logger.New("order-service", "production")
 log := logger.New("order-service", "local", logger.WithLevel(logger.DebugLevel))

--- a/messaging/scheduler/README.md
+++ b/messaging/scheduler/README.md
@@ -7,7 +7,7 @@ AWS EventBridge Scheduler client with OTel tracing.
 ## Setup
 
 ```go
-import "github.com/juanmaAV/go-utils/messaging/scheduler"
+import "github.com/juanMaAV92/go-utils/messaging/scheduler"
 
 cfg, err := scheduler.ConfigFromEnv("SCHEDULER")
 sched, err := scheduler.New(ctx, cfg, logger)

--- a/messaging/sns/README.md
+++ b/messaging/sns/README.md
@@ -8,8 +8,8 @@ SNS producer with OTel tracing and W3C Trace Context propagation.
 
 ```go
 import (
-    "github.com/juanmaAV/go-utils/messaging/sns"
-    "github.com/juanmaAV/go-utils/messaging/sns/producer"
+    "github.com/juanMaAV92/go-utils/messaging/sns"
+    "github.com/juanMaAV92/go-utils/messaging/sns/producer"
 )
 
 snsCfg, err := sns.ConfigFromEnv("SNS")

--- a/messaging/sqs/README.md
+++ b/messaging/sqs/README.md
@@ -6,9 +6,9 @@ SQS producer and consumer with OTel tracing, W3C Trace Context propagation, SNS 
 
 ```go
 import (
-    "github.com/juanmaAV/go-utils/messaging/sqs"
-    "github.com/juanmaAV/go-utils/messaging/sqs/producer"
-    "github.com/juanmaAV/go-utils/messaging/sqs/consumer"
+    "github.com/juanMaAV92/go-utils/messaging/sqs"
+    "github.com/juanMaAV92/go-utils/messaging/sqs/producer"
+    "github.com/juanMaAV92/go-utils/messaging/sqs/consumer"
 )
 
 // 1. Create the base SQS client (shared by producer and consumer)

--- a/middleware/identity/README.md
+++ b/middleware/identity/README.md
@@ -20,7 +20,7 @@ API Gateway
 ## Setup
 
 ```go
-import "github.com/juanmaAV/go-utils/middleware/identity"
+import "github.com/juanMaAV92/go-utils/middleware/identity"
 
 e.Use(identity.Middleware(identity.HeaderConfig{
     Extra: []string{"X-User-Nature", "X-Hierarchy-Path", "X-Abac-JWT"},

--- a/pointers/README.md
+++ b/pointers/README.md
@@ -37,7 +37,7 @@ Dereferences `s`. Returns `""` if nil.
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/pointers"
+import "github.com/juanMaAV92/go-utils/pointers"
 
 p := pointers.Pointer(42)             // *int
 s := pointers.Pointer("hello")        // *string

--- a/security/jwt/README.md
+++ b/security/jwt/README.md
@@ -21,7 +21,7 @@ type MyClaims struct {
 ### 2. Create the service
 
 ```go
-import "github.com/juanmaAV/go-utils/security/jwt"
+import "github.com/juanMaAV92/go-utils/security/jwt"
 
 svc, err := jwt.New(privateKeyPEM, publicKeyPEM, "my-service")
 ```

--- a/storage/s3/README.md
+++ b/storage/s3/README.md
@@ -5,7 +5,7 @@ S3 client with OTel tracing and structured logging. Supports direct backend oper
 ## Setup
 
 ```go
-import "github.com/juanmaAV/go-utils/storage/s3"
+import "github.com/juanMaAV92/go-utils/storage/s3"
 
 cfg, err := s3.ConfigFromEnv("S3")
 if err != nil {

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -19,7 +19,7 @@ type Config struct {
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/telemetry"
+import "github.com/juanMaAV92/go-utils/telemetry"
 
 shutdown, err := telemetry.InitTelemetry(ctx, telemetry.Config{
     ServiceName: "order-service",

--- a/testutil/echo/README.md
+++ b/testutil/echo/README.md
@@ -10,7 +10,7 @@ import (
     "testing"
 
     "github.com/labstack/echo/v4"
-    echotest "github.com/juanmaAV/go-utils/testutil/echo"
+    echotest "github.com/juanMaAV92/go-utils/testutil/echo"
 )
 
 func TestCreateOrder(t *testing.T) {

--- a/testutil/http/README.md
+++ b/testutil/http/README.md
@@ -10,7 +10,7 @@ import (
     "net/http/httptest"
     "testing"
 
-    httptest "github.com/juanmaAV/go-utils/testutil/http"
+    httptest "github.com/juanMaAV92/go-utils/testutil/http"
 )
 
 func TestGetUser(t *testing.T) {

--- a/timeutil/README.md
+++ b/timeutil/README.md
@@ -45,7 +45,7 @@ Preserve the original location. Useful for date-range queries.
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/timeutil"
+import "github.com/juanMaAV92/go-utils/timeutil"
 
 // Use constants to avoid the magic format string
 t.Format(timeutil.DateLayout)      // "2024-03-15"

--- a/validator/README.md
+++ b/validator/README.md
@@ -28,7 +28,7 @@ type Binder interface {
 ## Usage
 
 ```go
-import "github.com/juanmaAV/go-utils/validator"
+import "github.com/juanMaAV92/go-utils/validator"
 
 v := validator.New()
 
@@ -43,7 +43,7 @@ err := v.BindAndValidate(c, &req)
 
 ```go
 import (
-    "github.com/juanmaAV/go-utils/validator"
+    "github.com/juanMaAV92/go-utils/validator"
     "github.com/labstack/echo/v4"
 )
 


### PR DESCRIPTION
## Changes

- Add **MIT LICENSE** (the README already declared MIT but the file was missing).
- Fix README import paths from `github.com/juanmaAV/go-utils` to the correct module path `github.com/juanMaAV92/go-utils` across all package docs — the previous casing made `go get` and import examples fail.